### PR TITLE
Added action on PRE elements + French translations

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,4 @@
 Redmine plugin to collapse quotes in issue history.
+History
+* v 0.0.2:
+ ** Made image links be relative so that it both works with redmine installed at the root or in a subfolder (such as /redmine)

--- a/app/views/hooks/_view_issues_show_description_bottom.html.erb
+++ b/app/views/hooks/_view_issues_show_description_bottom.html.erb
@@ -9,11 +9,11 @@ a.toggle-quoted-text {
 }
 
 a.quoted-text-collapsed {
-  background-image: url(/images/arrow_collapsed.png);
+  background-image: url(../images/arrow_collapsed.png);
 }
 
 a.quoted-text-expanded {
-  background-image: url(/images/arrow_expanded.png);
+  background-image: url(../images/arrow_expanded.png);
 }
 </style>
 

--- a/assets/javascripts/collapse_quotes.js
+++ b/assets/javascripts/collapse_quotes.js
@@ -1,6 +1,6 @@
 $(function() {
-  $('#history > div.has-notes').each(function(i) {
-    $(this).find("blockquote").each(function(i) {
+  $('#history div.has-notes').each(function(i) {
+    $(this).find("blockquote,pre").each(function(i) {
       q = $(this);
       if (q.height() < 100)
         return;
@@ -14,7 +14,7 @@ $(function() {
 
 function toggleQuotedTextVisibility(a) {
   a = $(a);
-  q = a.next("blockquote");
+  q = a.next("blockquote,pre");
   q.toggle();
   // reflect current visibility state
   if (q.is(':visible')) {

--- a/assets/javascripts/collapse_quotes.js
+++ b/assets/javascripts/collapse_quotes.js
@@ -1,29 +1,30 @@
-Event.observe(window, 'load', function() {
-  $$('#history > div.has-notes').each(function(div) {
-    div.select('blockquote').each(function(blockquote) {
-      if (blockquote.getHeight() < 100)
+$(function() {
+  $('#history > div.has-notes').each(function(i) {
+    $(this).find("blockquote").each(function(i) {
+      q = $(this);
+      if (q.height() < 100)
         return;
 
-      anchor = '<a class="toggle-quoted-text quoted-text-collapsed" href="#" onclick="return toggleQuotedTextVisibility(this);">' + getShowQuotedTextString() + '</a>';
-      blockquote.insert({ before: anchor });
-      blockquote.hide();
+      a = '<a class="toggle-quoted-text quoted-text-collapsed" href="#" onclick="return toggleQuotedTextVisibility(this);">' + getShowQuotedTextString() + '</a>';
+      q.before(a);
+      q.hide();
     });
   });
 });
 
-function toggleQuotedTextVisibility(anchor) {
-  anchor = $(anchor);
-  blockquote = anchor.next("blockquote");
-  blockquote.toggle();
+function toggleQuotedTextVisibility(a) {
+  a = $(a);
+  q = a.next("blockquote");
+  q.toggle();
   // reflect current visibility state
-  if (blockquote.visible()) {
-    anchor.innerText = getHideQuotedTextString();
-    anchor.removeClassName("quoted-text-collapsed");
-    anchor.addClassName("quoted-text-expanded");
+  if (q.is(':visible')) {
+    a.text(getHideQuotedTextString());
+    a.removeClass("quoted-text-collapsed");
+    a.addClass("quoted-text-expanded");
   } else {
-    anchor.innerText = getShowQuotedTextString();
-    anchor.addClassName("quoted-text-collapsed");
-    anchor.removeClassName("quoted-text-expanded");
+    a.text(getShowQuotedTextString());
+    a.addClass("quoted-text-collapsed");
+    a.removeClass("quoted-text-expanded");
   }
   return false;
 }

--- a/assets/javascripts/collapse_quotes.js
+++ b/assets/javascripts/collapse_quotes.js
@@ -15,12 +15,13 @@ function toggleQuotedTextVisibility(anchor) {
   anchor = $(anchor);
   blockquote = anchor.next("blockquote");
   blockquote.toggle();
+  // reflect current visibility state
   if (blockquote.visible()) {
-    anchor.innerText = getShowQuotedTextString();
+    anchor.innerText = getHideQuotedTextString();
     anchor.removeClassName("quoted-text-collapsed");
     anchor.addClassName("quoted-text-expanded");
   } else {
-    anchor.innerText = getHideQuotedTextString();
+    anchor.innerText = getShowQuotedTextString();
     anchor.addClassName("quoted-text-collapsed");
     anchor.removeClassName("quoted-text-expanded");
   }

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,4 @@
+# English strings go here for Rails i18n
+fr:
+  label_show_quoted_text: "- Afficher la citation -"
+  label_hide_quoted_text: "- Masquer la citation -"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,0 +1,3 @@
+it:
+  label_show_quoted_text: "- Mostra testo citato -"
+  label_hide_quoted_text: "- Nascondi testo citato -"

--- a/init.rb
+++ b/init.rb
@@ -24,7 +24,7 @@ Redmine::Plugin.register :redmine_collapse_quotes do
   name 'Redmine Collapse Quotes plugin'
   author 'Alex Shulgin <ash@commandprompt.com>'
   description 'Redmine plugin to collapse quotes in issue history'
-  version '0.0.1'
+  version '0.0.2'
 #  url 'https://github.com/commandprompt/redmine_collapse_quotes/'
 #  author_url 'http://example.com/about'
 

--- a/init.rb
+++ b/init.rb
@@ -17,7 +17,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 require 'redmine'
-require 'dispatcher'
 
 require_dependency 'redmine_collapse_quotes/view_hooks'
 


### PR DESCRIPTION
- Changed the search to look for all "has-notes" class children, not only direct children: this is safer regarding possible future changes in Redmine pages.
- Added PRE tags to tags being possible to collapse
- Added French translations
